### PR TITLE
Fix FatFs for upstream KOS changes

### DIFF
--- a/fatfs/src/dc.c
+++ b/fatfs/src/dc.c
@@ -37,6 +37,7 @@
 #include <arch/rtc.h>
 #include <dc/g1ata.h>
 #include <dc/sd.h>
+#include <kos/dbglog.h>
 #include <kos/fs.h>
 #include <kos/mutex.h>
 #include <fatfs.h>

--- a/fatfs/src/dc.c
+++ b/fatfs/src/dc.c
@@ -731,7 +731,7 @@ static int fat_stat(struct vfs_handler *vfs, const char *path, struct stat *st, 
     (void)flag;
 
     memset(st, 0, sizeof(struct stat));
-    st->st_dev = (dev_t)((ptr_t)vfs);
+    st->st_dev = (dev_t)((uintptr_t)vfs);
     st->st_mode = S_IRUSR | S_IRGRP | S_IROTH | S_IXUSR | S_IXGRP | S_IXOTH;
     st->st_nlink = 1;
 
@@ -780,7 +780,7 @@ static int fat_fstat(void *hnd, struct stat *st) {
 
     st->st_nlink = 1;
     st->st_blksize = 1 << sf->mnt->dev->l_block_size;
-    st->st_dev = (dev_t)((ptr_t)sf->mnt->dev);
+    st->st_dev = (dev_t)((uintptr_t)sf->mnt->dev);
     st->st_mode = S_IRUSR | S_IRGRP | S_IROTH | S_IXUSR | S_IXGRP | S_IXOTH;
 
     if (sf->type == STAT_TYPE_DIR) {

--- a/fatfs/src/dc_bdev.c
+++ b/fatfs/src/dc_bdev.c
@@ -38,6 +38,7 @@
 #include <dc/g1ata.h>
 #include <dc/sd.h>
 #include <dc/scif.h>
+#include <kos/dbglog.h>
 #include <fatfs.h>
 
 #define MAX_PARTITIONS 4


### PR DESCRIPTION
Two changes:
1. `kos/dbglog.h` was accidentally being included in `stdio.h`, so we removed it in upstream KOS. It needs to be added here.
2. We removed the pointless `ptr_t` type and replaced all instances with `uintptr_t`. That also needs to be adjusted here.